### PR TITLE
Rewrote vario functionality

### DIFF
--- a/README
+++ b/README
@@ -1,3 +1,51 @@
+
+This fork adds a variometer, an instrument indicating vertical speed,
+essentially for use in free flight (paragliding, hang gliding, ...).
+
+Initially based on the vario source coded by dkm, I ended up rewriting
+that module completely.
+
+- Pressing the "v" (down) button cycles between displays as follows:
+        
+    * vario (in m/s)
+	  Displays a signed fractional value representing the ascent or
+          descent speed in meters per second.
+
+    * vario (in Pascal)
+          Displays a signed integer value representing the ascent or
+          descent speed in Pascal/second.
+
+    * pressure (in hPa)
+          Displays a signed fraction representing the pressure measured at
+          the current altitude.
+
+    * max Vz (in m/s)
+          Displays the maximum vertical speed in meters/second.
+
+    * min Vz (in m/s)
+          Displays the minimum vertical speed in meters/second.
+    
+- A long press on the "#" button performs a context sensitive function:
+    
+    * during vario display, changes the vario sound mode:
+      Off      (default, no symbol displayed)
+      Ascent 0 (start beeping at 0.0m/s, beeper1 and beeper2 symbols
+               displayed)
+      Ascent 1 (start beeping at 0.1m/s, beeper1 symbol displayed)
+      Both     (beep for up or down, beeper1 and beeper2 symbols
+               displayed)
+
+      Tone frequency, number and duration of beeps depend on climb rate.
+
+    * during max/min Vz display, resets both the max and min values.
+    
+- The "record" icon is flashed at one second intervals, indicating that
+  the watch is in vario mode and receiving pressure measurements.
+          
+  Note that the upper line must be in altimeter mode for the vario to
+  work, as it relies on updates from the altimeter. If the altimeter
+  is not active, the vario display shows "noAlt".
+
 == Status ==
 
 Works, but in development :-)

--- a/driver/buzzer.c
+++ b/driver/buzzer.c
@@ -129,7 +129,11 @@ void start_buzzer(u8 cycles, u16 on_time, u16 off_time)
 	}
 }
 
-
+void start_buzzer_steps(u8 cycles, u16 on_time, u16 off_time, u8 steps )
+{
+   sBuzzer.steps = steps;
+   start_buzzer( cycles, on_time, off_time );
+}
 
 // *************************************************************************************************
 // @fn          toggle_buzzer

--- a/driver/buzzer.h
+++ b/driver/buzzer.h
@@ -45,6 +45,7 @@
 // Prototypes section
 extern void reset_buzzer(void);
 extern void start_buzzer(u8 cycles, u16 on_time, u16 off_time);
+extern void start_buzzer_steps(u8 cycles, u16 on_time, u16 off_time, u8 steps);
 extern void stop_buzzer(void);
 extern void toggle_buzzer(void);
 extern u8 is_buzzer(void);

--- a/driver/timer.c
+++ b/driver/timer.c
@@ -65,14 +65,6 @@
 #include "acceleration.h"
 #endif
 
-#ifdef CONFIG_PROUT
-#include "prout.h"
-#endif
-
-#ifdef CONFIG_VARIO
-#include "vario.h"
-#endif
-
 //pfs
 #ifndef ELIMINATE_BLUEROBIN
 #include "bluerobin.h"
@@ -366,14 +358,6 @@ __interrupt void TIMER0_A0_ISR(void)
 			stop_alarm();
 		}
 	}
-
-#ifdef CONFIG_PROUT
-        if (is_prout()) prout_tick();
-#endif
-
-#ifdef CONFIG_VARIO
-        if(is_vario()) vario_tick();
-#endif
 
 #ifdef CONFIG_STRENGTH
         // One more second gone by.

--- a/ezchronos.c
+++ b/ezchronos.c
@@ -407,10 +407,6 @@ void init_global_variables(void)
         reset_prout();
 #endif
 
-#ifdef CONFIG_VARIO
-        reset_vario();
-#endif
-
 #ifdef CONFIG_PHASE_CLOCK
 	// default program
 	sPhase.program = 0;

--- a/logic/altitude.c
+++ b/logic/altitude.c
@@ -247,17 +247,17 @@ void do_altitude_measurement(u8 filter)
 		sAlt.pressure = pressure;
 	}
 
-#ifdef CONFIG_VARIO
-   // Stash a copy to the vario after filtering. If doing so before, there
-   // is just too much unnecessary fluctuation, up to +/- 7Pa seen.
-   vario_p_write( pressure );
-#endif
-	
 	// Convert pressure (Pa) and temperature (?K) to altitude (m).
 #ifdef FIXEDPOINT
 	sAlt.altitude = conv_pa_to_altitude(sAlt.pressure, sAlt.temperature);
 #else
     sAlt.altitude = conv_pa_to_meter(sAlt.pressure, sAlt.temperature);
+#endif
+
+#ifdef CONFIG_VARIO
+   // Stash a copy to the vario after filtering. If doing so before, there
+   // is just too much unnecessary fluctuation, up to +/- 7Pa seen.
+   vario_p_write( pressure );
 #endif
 }
 

--- a/logic/altitude.c
+++ b/logic/altitude.c
@@ -53,6 +53,9 @@
 
 // logic
 #include "user.h"
+#ifdef CONFIG_VARIO
+# include "vario.h"
+#endif
 
 
 // *************************************************************************************************
@@ -243,8 +246,14 @@ void do_altitude_measurement(u8 filter)
 		// Store average pressure
 		sAlt.pressure = pressure;
 	}
+
+#ifdef CONFIG_VARIO
+   // Stash a copy to the vario after filtering. If doing so before, there
+   // is just too much unnecessary fluctuation, up to +/- 7Pa seen.
+   vario_p_write( pressure );
+#endif
 	
-	// Convert pressure (Pa) and temperature (?K) to altitude (m)
+	// Convert pressure (Pa) and temperature (?K) to altitude (m).
 #ifdef FIXEDPOINT
 	sAlt.altitude = conv_pa_to_altitude(sAlt.pressure, sAlt.temperature);
 #else

--- a/logic/menu.c
+++ b/logic/menu.c
@@ -259,14 +259,14 @@ const struct menu menu_L2_Date =
 //Line 2 - Vario
 const struct menu menu_L2_Vario = 
   {
-	FUNCTION(sx_vario),			// direct function
-	FUNCTION(mx_vario),			// sub menu function
+	FUNCTION(sx_vario),		// direct function
+	FUNCTION(mx_vario),		// sub menu function
 	FUNCTION(menu_skip_next),	// next item function
-	FUNCTION(display_vario),		// display function
-	FUNCTION(update_vario),		// new display data
+	FUNCTION(display_vario),	// display function
+	FUNCTION(update_time),		// refresh display data once every second
 };
-
 #endif
+
 // Line2 - Stopwatch
 const struct menu menu_L2_Stopwatch =
 {

--- a/logic/vario.c
+++ b/logic/vario.c
@@ -453,6 +453,7 @@ display_vario( u8 line, u8 update )
    else
      {
 	display_chars(LCD_SEG_L2_5_0, (u8*) " NOALT", SEG_ON);
+	_idone = 0; // avoid false peaks when re-enabling the altimeter
      }
 }
 

--- a/logic/vario.c
+++ b/logic/vario.c
@@ -226,43 +226,15 @@ void chirp( s16 pdiff )
 }
 
 //
-// _display_fraction() - display a fraction on the second line, nnnn.nn
+// _display_signed() - display a signed value on the second line.
+// 
+// If is_fraction is false, display value on the second line, nnnnnn
+// Otherwise display value as fraction on the second line, nnnn.nn
 // 
 // Used to display pressure (in Pascal) as hPa and cm/s as m/s.
 //
 static void
-_display_fraction( s32 value )
-{
-   u8 *str;
-//   u16 m;
-   int i;
-   int is_neg;
-
-   is_neg = ( value < 0 );
-   if ( is_neg )
-	value *= -1;
-
-   str = itoa( value, 6, 3 );
-
-   for ( i = 0; (is_neg && (str[i] == ' ')); i++ )
-     {
-	if (str[i+1] != ' ')
-	  str[i] = '-';
-     }
-
-   display_chars( LCD_SEG_L2_5_0, str, SEG_ON );
-
-   display_symbol( LCD_SEG_L2_DP, SEG_ON );
-
-}
-
-//
-// _display_signed() - display a signed int on the second line, nnnnnn
-// 
-// Used to display pressure (in Pascal) as hPa and cm/s as m/s.
-//
-static void
-_display_signed( int value )
+_display_signed( s32 value, u8 is_fraction )
 {
    u8 *str;
    int i;
@@ -275,7 +247,7 @@ _display_signed( int value )
 	value *= -1;
      }
 
-   str = itoa( value, 6, 5 );
+   str = itoa( value, 6, (is_fraction) ? 3 : 5 );
 
    for ( i = 0; (is_neg && (str[i] == ' ')); i++ )
      {
@@ -285,6 +257,8 @@ _display_signed( int value )
 
    display_chars( LCD_SEG_L2_5_0, str, SEG_ON );
 
+   if ( is_fraction )
+   display_symbol( LCD_SEG_L2_DP, SEG_ON );
 }
 
 //
@@ -396,31 +370,31 @@ display_vario( u8 line, u8 update )
 	     //
 	     // convert the difference in Pa to a vertical velocity.
 	     //
-	     _display_fraction( _pascal_to_vz( diff ) );
+	     _display_signed( _pascal_to_vz( diff ), 1 );
 	     break;
 
 	   case VARIO_VIEWMODE_ALT_PA:
 	     //
 	     // display raw difference in Pascal.
 	     //
-	     _display_signed( diff );
+	     _display_signed( diff, 0 );
 	     break;
 
 	   case VARIO_VIEWMODE_PA:
 	     //
 	     // display pressure as hhhh.pp (hPa and Pa)
 	     //
-	     _display_fraction( pressure );
+	     _display_signed( pressure, 1 );
 	     break;
 
 	   case VARIO_VIEWMODE_VZMAX:
 	     display_symbol( LCD_SYMB_MAX, SEG_ON);
-	     _display_fraction( _pascal_to_vz( G_vario.stats.vzmax )  );
+	     _display_signed( _pascal_to_vz( G_vario.stats.vzmax ), 1  );
 	     break;
 
 	   case VARIO_VIEWMODE_VZMIN:
 	     display_symbol( LCD_SYMB_MAX, SEG_ON);
-	     _display_fraction( _pascal_to_vz( G_vario.stats.vzmin ) );
+	     _display_signed( _pascal_to_vz( G_vario.stats.vzmin ), 1 );
 	     break;
 
 	   case VARIO_VIEWMODE_MAX:

--- a/logic/vario.c
+++ b/logic/vario.c
@@ -331,6 +331,22 @@ _pascal_to_vz( s32 pa )
 }
 
 //
+// Common function to turn off various symbols we use in our view modes.
+//
+void
+_display_l2_clean( void ) 
+{
+#if ( VARIO_VZ || VARIO_ALTMAX ) 
+   display_symbol( LCD_SYMB_MAX, SEG_OFF);
+#endif
+
+#if VARIO_F_TIME
+   display_symbol(LCD_SEG_L2_COL1, SEG_OFF);
+   display_symbol(LCD_SEG_L2_COL0, SEG_OFF);
+#endif
+}
+
+//
 // Vario display update function. Theorethically called once per second.
 // In practice, this also gets called on button presses, so careful if
 // you rely on it for a 1Hz frequency.
@@ -352,9 +368,7 @@ display_vario( u8 line, u8 update )
 	display_symbol( LCD_ICON_BEEPER1, SEG_OFF );
 	display_symbol( LCD_ICON_BEEPER2, SEG_OFF );
 	display_symbol( LCD_ICON_RECORD,  SEG_OFF );
-#if ( VARIO_VZ || VARIO_ALTMAX ) 
-	display_symbol( LCD_SYMB_MAX,     SEG_OFF );
-#endif
+	_display_l2_clean();
 	return;
 
       case DISPLAY_LINE_UPDATE_FULL:
@@ -439,19 +453,11 @@ display_vario( u8 line, u8 update )
 #endif
 	  }
 
-
+	_display_l2_clean();
 	// Pulse the vario heartbeat indicator.
 	++_vbeat;
 	display_symbol( LCD_ICON_RECORD, ( _vbeat & 1 ) ? SEG_ON : SEG_OFF );
-
-#if ( VARIO_VZ || VARIO_ALTMAX ) 
-	display_symbol( LCD_SYMB_MAX, SEG_OFF);
-#endif
-
-#if VARIO_F_TIME
-	display_symbol(LCD_SEG_L2_COL1, SEG_OFF);
-	display_symbol(LCD_SEG_L2_COL0, SEG_OFF);
-#endif
+	
 	// Now see what value to display.
 
 	switch( G_vario.view_mode )
@@ -535,6 +541,7 @@ display_vario( u8 line, u8 update )
      } // L1 is in altimeter mode
    else
      {
+	_display_l2_clean();
 	display_chars(LCD_SEG_L2_5_0, (u8*) " NOALT", SEG_ON);
 	_idone = 0; // avoid false peaks when re-enabling the altimeter
      }

--- a/logic/vario.c
+++ b/logic/vario.c
@@ -200,7 +200,7 @@ void chirp( s16 pdiff )
    const u8 range_steps  = 5;
    u8 bsteps;
    u8 nchirps;
-   u8 on_time;
+   u16 on_time;
 
    //
    // Buzzer steps (see driver/buzzer) 3..23 provide a frequency
@@ -217,11 +217,11 @@ void chirp( s16 pdiff )
    // update comes along.
    //
    if ( nchirps > 50 ) nchirps = 50;   // Wouah, 25m/s - up or down?
-   on_time = 500 / nchirps;            // 500ms on time max, same for off time
+   on_time = 500 / nchirps;            // 500ms on time max, half for off time
 
    start_buzzer_steps( nchirps, 
 		       CONV_MS_TO_TICKS( on_time ),
-		       CONV_MS_TO_TICKS( on_time ),
+		       CONV_MS_TO_TICKS( on_time / 2 ),
 		       bsteps );
 }
 

--- a/logic/vario.c
+++ b/logic/vario.c
@@ -62,6 +62,7 @@
 #include "buzzer.h"
 
 // logic
+#include "altitude.h"
 #include "vario.h"
 
 //
@@ -82,6 +83,7 @@ struct
      {
 	s16 vzmin; // Vz min in Pascal
 	s16 vzmax; // Vz max in Pascal
+	u16 altmax; // altitude max
      } stats;
 } G_vario;
 
@@ -107,6 +109,7 @@ enum
    VARIO_VIEWMODE_PA,         // Display current pressure
    VARIO_VIEWMODE_VZMAX,      // Max Vario (positive)
    VARIO_VIEWMODE_VZMIN,      // Max Vario (positive)
+   VARIO_VIEWMODE_ALT_MAX,    // Max altitude
    VARIO_VIEWMODE_MAX
 };
 
@@ -118,6 +121,7 @@ _clear_stats( void )
 {
    G_vario.stats.vzmin = 0;
    G_vario.stats.vzmax = 0;
+   G_vario.stats.altmax = 0;
 }
 
 // "v" button press changes display mode
@@ -142,7 +146,8 @@ mx_vario(u8 line)
 	G_vario.beep_mode++;
 	G_vario.beep_mode %= VARIO_BEEPMODE_MAX;
 	break;
-      
+
+      case VARIO_VIEWMODE_ALT_MAX:
       case VARIO_VIEWMODE_VZMAX:
       case VARIO_VIEWMODE_VZMIN:
 	_clear_stats();
@@ -353,6 +358,10 @@ display_vario( u8 line, u8 update )
 
 	     if ( diff > G_vario.stats.vzmax ) G_vario.stats.vzmax = diff;
 	     if ( diff < G_vario.stats.vzmin ) G_vario.stats.vzmin = diff;
+
+	     // Peek at current altitude in altimeter data.
+	     if ( G_vario.stats.altmax < sAlt.altitude )
+	       G_vario.stats.altmax = sAlt.altitude;
 	  }
 
 
@@ -395,6 +404,11 @@ display_vario( u8 line, u8 update )
 	   case VARIO_VIEWMODE_VZMIN:
 	     display_symbol( LCD_SYMB_MAX, SEG_ON);
 	     _display_signed( _pascal_to_vz( G_vario.stats.vzmin ), 1 );
+	     break;
+
+	   case VARIO_VIEWMODE_ALT_MAX:
+	     display_symbol( LCD_SYMB_MAX, SEG_ON);
+	     _display_signed( G_vario.stats.altmax, 0 );
 	     break;
 
 	   case VARIO_VIEWMODE_MAX:

--- a/logic/vario.c
+++ b/logic/vario.c
@@ -389,20 +389,26 @@ display_vario( u8 line, u8 update )
 
 #if VARIO_F_TIME
    // Update flight time regardless of whether we do have an altitude.
-
-   G_vario.stats.f_time.ss++;
-   if ( G_vario.stats.f_time.ss > 59 )
+   //
+   // Be careful to only update the time when a time update is active,
+   // ie, not because this refresh is due to a DOWN button press.
+   //
+   if ( display.flag.update_time )
      {
-	G_vario.stats.f_time.ss = 0;
-	G_vario.stats.f_time.mm++;
-	if ( G_vario.stats.f_time.mm > 59 )
+	G_vario.stats.f_time.ss++;
+	if ( G_vario.stats.f_time.ss > 59 )
 	  {
 	     G_vario.stats.f_time.ss = 0;
-	     G_vario.stats.f_time.hh++;
+	     G_vario.stats.f_time.mm++;
+	     if ( G_vario.stats.f_time.mm > 59 )
+	       {
+		  G_vario.stats.f_time.mm = 0;
+		  G_vario.stats.f_time.hh++;
+	       }
+	     // Reset flight time after 19 hours, more will not fit on lcd !
+	     if ( G_vario.stats.f_time.hh > 19 )
+	       G_vario.stats.f_time.hh = 0;
 	  }
-	// Never mind if hours exceeds 24... but reset after 99 !
-	if ( G_vario.stats.f_time.hh > 99 )
-	  G_vario.stats.f_time.hh = 0;
      }
 #endif
 

--- a/logic/vario.h
+++ b/logic/vario.h
@@ -1,6 +1,8 @@
 /*
-    Vario function for ez430 chronos watch.
-    Copyright (C) 2010 Marc Poulhiès <dkm@kataplop.net>
+    Altivario function for ez430 chronos watch.
+    Copyright (C) 2011, Marc Bongartz <mbong@free.fr>
+
+    Build environment Copyright (C) 2010 Marc Poulhi<E8>s <dkm@kataplop.net>
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -54,27 +56,12 @@
 #ifndef VARIO_H_
 #define VARIO_H_
 
-// menu functions
+// menu function callbacks
 extern void sx_vario(u8 line);
 extern void mx_vario(u8 line);
 extern void display_vario(u8 line, u8 update);
 
-extern void reset_vario(void);
-extern void vario_tick(void);
-extern void update_vario(void);
-extern u8 is_vario(void);
+// external function to update the pressure value.
+extern void vario_p_write(u32);
 
-#define VARIO_STOP	(0u)
-#define VARIO_RUN	(1u)
-
-#define VARIO_HIST_SIZE 10
-
-struct vario
-{
-  u8 state;
-  u8 hist_alts[VARIO_HIST_SIZE];
-  u8 hist_count, hist_pos;
-};
-
-extern struct vario svario;
 #endif


### PR DESCRIPTION
Hi folks,

I've rewritten the variometer functionality originally implemented by dkm, he's okay to replace it with my changes (discussed on a french paragliding forum, http://www.parapentiste.info/forum/instruments-de-vol/ti-ez430chrono-t15832.0.html - all in french though).

From a user perspective, the new vario provides a display of ascent/descent speed, in m/s or Pascal/s, barometric pressure in hPa, and max/min vertical speeds. Audible indications can be turned on/off for ascent and descent, and the stats can be reset.

The compiled code occupîes 970 bytes when enabled, and is conditionalised by the existing build framework (in make config).

Let me know if you want to pull these changes into the master.

Regards,
Marc
