### PR TITLE
Silent fix

### DIFF
--- a/ezchronos.c
+++ b/ezchronos.c
@@ -648,7 +648,7 @@ void display_update(void)
 		if (message.flag.type_locked)			memcpy(string, "  LOCT", 6);
 		else if (message.flag.type_unlocked)	memcpy(string, "  OPEN", 6);
 		else if (message.flag.type_lobatt)		memcpy(string, "LOBATT", 6);
-		else if (message.flag.type_no_beep_on)  memcpy(string, " SILNC", 6);
+		else if (message.flag.type_no_beep_on)  memcpy(string, " SILNT", 6);
 		else if (message.flag.type_no_beep_off) memcpy(string, "  BEEP", 6);
 		#ifdef CONFIG_ALARM 
 		else if (message.flag.type_alarm_on)	


### PR DESCRIPTION
Simple fix for an assumed typo. "SILNC" should be "SILNT"
