### PR TITLE
Two fixes

### DIFF
--- a/ezchronos.c
+++ b/ezchronos.c
@@ -444,7 +444,7 @@ void wakeup_event(void)
 	if (button.all_flags && sys.flag.lock_buttons)
 	{
 		// Show "buttons are locked" message synchronously with next second tick
-		if (!(BUTTON_NUM_IS_PRESSED && BUTTON_DOWN_IS_PRESSED))
+		if (!((BUTTON_NUM_IS_PRESSED && BUTTON_DOWN_IS_PRESSED) || BUTTON_BACKLIGHT_IS_PRESSED))
 		{
 			message.flag.prepare     = 1;
 			message.flag.type_locked = 1;

--- a/makefile
+++ b/makefile
@@ -3,7 +3,7 @@
 CPU	= MSP430
 CC  = msp430-gcc
 LD  = msp430-ld
-PYTHON = python
+PYTHON = python2
 
 PROJ_DIR	=.
 BUILD_DIR = build
@@ -108,11 +108,11 @@ build:
 	mkdir -p build
 
 config.h:
-	python tools/config.py
+	$(PYTHON) tools/config.py
 	git update-index --assume-unchanged config.h 2> /dev/null || true
 
 config:
-	python tools/config.py
+	$(PYTHON) tools/config.py
 	git update-index --assume-unchanged config.h 2> /dev/null || true
 
 help:

--- a/tools/config.py
+++ b/tools/config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # encoding: utf-8
 
 import urwid

--- a/tools/elf.py
+++ b/tools/elf.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # $Id: elf.py,v 1.1 2006/04/11 18:35:23 cliechti Exp $
 
 import struct

--- a/tools/memory.py
+++ b/tools/memory.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # $Id: memory.py,v 1.4.2.1 2009/05/19 09:07:21 rlim Exp $
 import sys
 import elf


### PR DESCRIPTION
Hello, this is path which just replaces abstract python execs with python2 ones.
This is very sensitive for ArchLinux users because their distro uses python3 as a default python interpreter.
Another fix is to prevent device from showing lock on line2 on each press of backlight while in locked mode.
