### PR TITLE
Morsetime

### DIFF
--- a/tools/config.py
+++ b/tools/config.py
@@ -230,6 +230,11 @@ DATA["CONFIG_USE_GPS"] = {
 	"depends": [],
 	"default": False}
 
+DATA["CONFIG_CW_TIME"] = {
+        "name": "CW Time",
+        "depends": [],
+        "default": False,
+	"help": "Send time in morse code"}
 
 HEADER = """
 #ifndef _CONFIG_H_


### PR DESCRIPTION
This fork adds send time in morse code (over buzzer) feature. When you switched the watch
to display seconds it would cache the current time and send it once in Morse
 code. To set morse speed edit  CW_DIT_LEN CONV_MS_TO_TICKS(50) in ezchronos.c
I configuration  set CW Time to enable this fork.
