### PR TITLE
Fixed order of menu_L2_Stopwatch so reset works

### DIFF
--- a/logic/menu.c
+++ b/logic/menu.c
@@ -297,8 +297,8 @@ const struct menu menu_L2_Vario =
 const struct menu menu_L2_Stopwatch =
 {
 	FUNCTION(sx_stopwatch),		// direct function
-	FUNCTION(menu_skip_next),	// next item function
 	FUNCTION(mx_stopwatch),		// sub menu function
+	FUNCTION(menu_skip_next),	// next item function
 	FUNCTION(display_stopwatch),// display function
 	FUNCTION(update_stopwatch),	// new display data
 };


### PR DESCRIPTION
My stopwatch would not reset properly.  Holding down # just eventually switched to the eggtimer. After some poking around, I discovered that menu_L2_Stopwatch listed the functions in the wrong order.  mx_stopwatch should be the second entry, not the third.

This commit fixes that problem, so holding down # will reset the stopwatch to 0.
