### PR TITLE
Updates the hidden menu RFBSL to work better.

### DIFF
--- a/README
+++ b/README
@@ -1,24 +1,23 @@
 
-Updates the eggtimer to be fully working, with a slightly reduced code-size.
+Updates the hidden menu RFBSL to work better.
 
 
 == Status ==
 
-Should be fully functional. Can be run concurrently with the stopwatch
-without harm.  Can also be run in the background (i.e. you can navigate
-away from its menu and it will still run and go off at the correct time.)
+Should be fully functional.  The hidden menu RFBSL places the wireless
+update (RFBSL) menu entry as a sub-menu with the battery voltage monitor.
 
-The icon used for it ("R" with a circle around it) is on solid for when
-its menu entry is active, and blinks when running, even if on a separate
-menu (menu entry not active).
+This update makes toggling between the battery and rfbsl behave like a
+normal submenu (uses the down arrow), as well as fixes some pre-processor
+issues.  Specifically, disabling the battery voltage monitor AND enabling
+the hidden rfbsl menu would result in no rfbsl menu, forcing the user to
+use the (SLOW!) USB programmer for the next firmware upload.
 
-Resolution is in seconds, maximum hours is 19, max minutes is 99, and max
-seconds is 99. (Note that a time of 2:90:00 == 3:30:00, since the minutes
-will rollover to 59 after 90 minutes, not back up to 90 --> 2:90:00...
-2:89:59...2:89:58......2:00:01...2:00:00...1:59:59...)
-
-These updates reduce the (.elf) delta compiled codesize by about 40 bytes,
-from 1524 to 1480.
+To-do idea (from gibbons): merge the battery, rfbsl, and sync functions
+all into one menu (a "hardware" or "tools" menu, for example). Ideally,
+also make it easier to pick and choose from these three options without
+needing ridiculous preprocessor commands, e.g.
+#if !defined(CONFIG_BATTERY) && defined(CONFIG_DISCRET_RFBSL) && ...
 
 
 == Requirements ==

--- a/logic/menu.c
+++ b/logic/menu.c
@@ -318,15 +318,18 @@ const struct menu menu_L2_Eggtimer =
 #ifdef CONFIG_BATTERY
 const struct menu menu_L2_Battery =
 {
-	FUNCTION(dummy),					// direct function
-	#ifndef CONFIG_USE_DISCRET_RFBSL
-	FUNCTION(dummy),					// sub menu function
+	#ifdef CONFIG_USE_DISCRET_RFBSL
+	FUNCTION(sx_rfbsl), // sub menu function
+	FUNCTION(mx_rfbsl), // direct function
+	FUNCTION(nx_rfbsl), // next item function
+	FUNCTION(display_discret_rfbsl),
 	#else
-	FUNCTION(sx_rfbsl),					//sub function calls RFBSL
+	FUNCTION(dummy), // sub menu function
+	FUNCTION(dummy), // direct function
+	FUNCTION(menu_skip_next), // next item function
+	FUNCTION(display_battery_V), // display function
 	#endif
-	FUNCTION(menu_skip_next),			// next item function
-	FUNCTION(display_battery_V),		// display function
-	FUNCTION(update_battery_voltage),	// new display data
+	FUNCTION(update_battery_voltage), // new display data
 };
 #endif
 #ifdef CONFIG_PHASE_CLOCK
@@ -388,7 +391,10 @@ const struct menu menu_L2_CalDist =
 	//&menu_L2_RFBSL,
 };
 #endif
-#ifndef CONFIG_USE_DISCRET_RFBSL
+
+// Include independent RFBSL menu if battery menu disabled, or if user didn't
+// want the hidden RFBSL menu
+#if !defined(CONFIG_BATTERY) || !defined(CONFIG_USE_DISCRET_RFBSL)
 // Line2 - RFBSL
 const struct menu menu_L2_RFBSL =
 {
@@ -497,7 +503,7 @@ const struct menu *menu_L2[]={
 	#ifndef ELIMINATE_BLUEROBIN
 	&menu_L2_CalDist,
 	#endif
-	#ifndef CONFIG_USE_DISCRET_RFBSL
+	#if !defined(CONFIG_USE_DISCRET_RFBSL) || !defined(CONFIG_BATTERY)
 	&menu_L2_RFBSL,
 	#endif
 	#ifdef CONFIG_PROUT

--- a/logic/menu.h
+++ b/logic/menu.h
@@ -116,7 +116,7 @@ extern const struct menu menu_L2_Sync;
 
 extern const struct menu menu_L2_CalDist;
 
-#ifndef CONFIG_USE_DISCRET_RFBSL
+#if !defined(CONFIG_BATTERY) || !defined(CONFIG_USE_DISCRET_RFBSL)
 extern const struct menu menu_L2_RFBSL;
 #endif
 

--- a/logic/rfbsl.h
+++ b/logic/rfbsl.h
@@ -42,6 +42,9 @@ extern void sx_rfbsl(u8 line);
 extern void mx_rfbsl(u8 line);
 extern void nx_rfbsl(u8 line);
 extern void display_rfbsl(u8 line, u8 update);
+#if defined(CONFIG_USE_DISCRET_RFBSL) && defined(CONFIG_BATTERY)
+extern void display_discret_rfbsl(u8 line, u8 update);
+#endif
 
 
 // *************************************************************************************************


### PR DESCRIPTION
Hello, this fixes some issues I found a while ago with the hidden menu RFBSL feature.  This fix has been implemented in my master (RTC) branch for some time, I just hadn't gotten around to submitting a pull request until now.

Specifically, this implements the hidden menu RFBSL ("discret_rfbsl") as a normal sub-menu of the battery (when enabled), making the buttons somewhat more intuitive, in my opinion. It also fixes some potential issues with the preprocessor commands: formerly, if the user didn't select the battery module (CONFIG_BATTERY not defined), but did select the hidden RFBSL option (CONFIG_USE_DISCRET_RFBSL defined), the RFBSL menu wouldn't have been created, meaning that there would have been no way to do a wireless firmware update! (You would have had to disassemble the watch and resort to the slow USB programmer.)

[To clear up any possible confusion, my "poelzi_clone" branch is where I debug and test my code on your semi-official OpenChronos master branch, before I submit the pull-request.  My master branch (which uses the Real Time Clock) is still too different to make such testing meaningful!]
