### PR TITLE
Feet/Meters-only options for the altimeter

### DIFF
--- a/logic/altitude.c
+++ b/logic/altitude.c
@@ -327,7 +327,7 @@ void mx_altitude(u8 line)
 	if (sys.flag.use_metric_units)
 	{
 #endif
-#if defined(CONFIG_ALTITUDE_UNIT_SETTABLE) | defined(CONFIG_ALTITUDE_UNIT_METERS)
+#if defined(CONFIG_ALTITUDE_UNIT_SETTABLE) || defined(CONFIG_ALTITUDE_UNIT_METERS)
 		// Display "m" symbol
 		display_symbol(LCD_UNIT_L1_M, SEG_ON);
 
@@ -343,7 +343,7 @@ void mx_altitude(u8 line)
 	else // English units
 	{
 #endif
-#if defined(CONFIG_ALTITUDE_UNIT_SETTABLE) | defined(CONFIG_ALTITUDE_UNIT_FEET)
+#if defined(CONFIG_ALTITUDE_UNIT_SETTABLE) || defined(CONFIG_ALTITUDE_UNIT_FEET)
 		// Display "ft" symbol
 		display_symbol(LCD_UNIT_L1_FT, SEG_ON);
 		
@@ -378,7 +378,7 @@ void mx_altitude(u8 line)
 			if (!sys.flag.use_metric_units)
 			{
 #endif
-#if defined(CONFIG_ALTITUDE_UNIT_SETTABLE) | defined(CONFIG_ALTITUDE_UNIT_FEET)
+#if defined(CONFIG_ALTITUDE_UNIT_SETTABLE) || defined(CONFIG_ALTITUDE_UNIT_FEET)
 				altitude = convert_ft_to_m((s16)altitude);
 #endif
 #ifdef CONFIG_ALTITUDE_UNIT_SETTABLE
@@ -419,7 +419,7 @@ void mx_altitude(u8 line)
 void display_altitude(u8 line, u8 update)
 {
 	u8 * str;
-#if defined(CONFIG_ALTITUDE_UNIT_SETTABLE) | defined(CONFIG_ALTITUDE_UNIT_FEET)
+#if defined(CONFIG_ALTITUDE_UNIT_SETTABLE) || defined(CONFIG_ALTITUDE_UNIT_FEET)
 	s16 ft;
 #endif
 	
@@ -438,8 +438,9 @@ void display_altitude(u8 line, u8 update)
 		if (sys.flag.use_metric_units)
 		{
 #endif
-#if defined(CONFIG_ALTITUDE_UNIT_SETTABLE) | defined(CONFIG_ALTITUDE_UNIT_METERS)
+#if defined(CONFIG_ALTITUDE_UNIT_SETTABLE) || defined(CONFIG_ALTITUDE_UNIT_METERS)
 			// Display "m" symbol
+			display_symbol(LCD_UNIT_L1_FT, SEG_OFF);
 			display_symbol(LCD_UNIT_L1_M, SEG_ON);
 #endif
 #ifdef CONFIG_ALTITUDE_UNIT_SETTABLE
@@ -447,8 +448,9 @@ void display_altitude(u8 line, u8 update)
 		else
 		{
 #endif
-#if defined(CONFIG_ALTITUDE_UNIT_SETTABLE) | defined(CONFIG_ALTITUDE_UNIT_FEET)
+#if defined(CONFIG_ALTITUDE_UNIT_SETTABLE) || defined(CONFIG_ALTITUDE_UNIT_FEET)
 			// Display "ft" symbol
+			display_symbol(LCD_UNIT_L1_M, SEG_OFF);
 			display_symbol(LCD_UNIT_L1_FT, SEG_ON);
 #endif
 #ifdef CONFIG_ALTITUDE_UNIT_SETTABLE
@@ -466,7 +468,7 @@ void display_altitude(u8 line, u8 update)
 			if (sys.flag.use_metric_units)
 			{
 #endif
-#if defined(CONFIG_ALTITUDE_UNIT_SETTABLE) | defined(CONFIG_ALTITUDE_UNIT_METERS)
+#if defined(CONFIG_ALTITUDE_UNIT_SETTABLE) || defined(CONFIG_ALTITUDE_UNIT_METERS)
 				// Display altitude in xxxx m format, allow 3 leading blank digits
 				if (sAlt.altitude >= 0)
 				{
@@ -481,9 +483,9 @@ void display_altitude(u8 line, u8 update)
 				else
 				{
 #ifdef CONFIG_ALTI_ACCUMULATOR
-					str = itoa(sAlt.altitude*(-1), 4, 3);
-#else
 					str = itoa(sAlt.altitude*(-1), 5, 4);
+#else
+					str = itoa(sAlt.altitude*(-1), 4, 3);
 #endif
 					display_symbol(LCD_SYMB_ARROW_UP, SEG_OFF);
 					display_symbol(LCD_SYMB_ARROW_DOWN, SEG_ON);
@@ -494,10 +496,10 @@ void display_altitude(u8 line, u8 update)
 			else
 			{
 #endif
-#if defined(CONFIG_ALTITUDE_UNIT_SETTABLE) | defined(CONFIG_ALTITUDE_UNIT_FEET)
+#if defined(CONFIG_ALTITUDE_UNIT_SETTABLE) || defined(CONFIG_ALTITUDE_UNIT_FEET)
 				// Convert from meters to feet
 				ft = convert_m_to_ft(sAlt.altitude);
-#ifndef CONFIG_ALTI_ACCUMULATOR
+#ifdef CONFIG_ALTI_ACCUMULATOR
 				// Limit to 9999ft (3047m)
 				if (ft > 9999) ft = 9999;
 #endif
@@ -505,19 +507,19 @@ void display_altitude(u8 line, u8 update)
 				if (ft >= 0)
 				{
 #ifdef CONFIG_ALTI_ACCUMULATOR
-					str = itoa(ft, 4, 3);
-#else
 					str = itoa(ft, 5, 4);
+#else
+					str = itoa(ft, 4, 3);
 #endif
 					display_symbol(LCD_SYMB_ARROW_UP, SEG_ON);
 					display_symbol(LCD_SYMB_ARROW_DOWN, SEG_OFF);
 				}
 				else
 				{
-#ifdef CONFIG_ALTI_ACCUMULATOR
-					str = itoa(ft*(-1), 4, 3);
-#else
+#ifndef CONFIG_ALTI_ACCUMULATOR
 					str = itoa(ft*(-1), 5, 4);
+#else
+					str = itoa(ft*(-1), 4, 3);
 #endif
 					display_symbol(LCD_SYMB_ARROW_UP, SEG_OFF);
 					display_symbol(LCD_SYMB_ARROW_DOWN, SEG_ON);

--- a/logic/altitude.c
+++ b/logic/altitude.c
@@ -69,6 +69,15 @@
 // *************************************************************************************************
 // Defines section
 
+#if defined(CONFIG_ALTITUDE_UNIT_FEET) && defined(CONFIG_ALTITUDE_UNIT_METERS)
+#error "You cannot define both CONFIG_ALTITUDE_UNIT_FEET and CONFIG_ALTITUDE_UNIT_METERS"
+#endif
+#if !defined(CONFIG_ALTITUDE_UNIT_FEET) && defined(CONFIG_METRIC_ONLY)
+#define CONFIG_ALTITUDE_UNIT_METERS
+#endif
+#if !defined(CONFIG_ALTITUDE_UNIT_FEET) && !defined(CONFIG_ALTITUDE_UNIT_METERS)
+#define CONFIG_ALTITUDE_UNIT_SETTABLE
+#endif
 
 // *************************************************************************************************
 // Global Variable section
@@ -132,7 +141,7 @@ void reset_altitude_measurement(void)
 	}
 }
 
-#ifndef CONFIG_METRIC_ONLY
+#if defined(CONFIG_ALTITUDE_UNIT_FEET) || defined(CONFIG_ALTITUDE_UNIT_SETTABLE)
 // *************************************************************************************************
 // @fn          conv_m_to_ft
 // @brief       Convert meters to feet
@@ -314,18 +323,11 @@ void mx_altitude(u8 line)
 #endif
 
 	// Set lower and upper limits for offset correction
-#ifdef CONFIG_METRIC_ONLY
-	display_symbol(LCD_UNIT_L1_M, SEG_ON);
-
-	// Convert global variable to local variable
-	altitude  = sAlt.altitude; 
-
-	// Limits for set_value function
-	limit_low = -100;
-	limit_high = 9000;
-#else
+#ifdef CONFIG_ALTITUDE_UNIT_SETTABLE
 	if (sys.flag.use_metric_units)
 	{
+#endif
+#if defined(CONFIG_ALTITUDE_UNIT_SETTABLE) | defined(CONFIG_ALTITUDE_UNIT_METERS)
 		// Display "m" symbol
 		display_symbol(LCD_UNIT_L1_M, SEG_ON);
 
@@ -335,9 +337,13 @@ void mx_altitude(u8 line)
 		// Limits for set_value function
 		limit_low = -100;
 		limit_high = 9000;
+#endif
+#ifdef CONFIG_ALTITUDE_UNIT_SETTABLE
 	}
 	else // English units
 	{
+#endif
+#if defined(CONFIG_ALTITUDE_UNIT_SETTABLE) | defined(CONFIG_ALTITUDE_UNIT_FEET)
 		// Display "ft" symbol
 		display_symbol(LCD_UNIT_L1_FT, SEG_ON);
 		
@@ -354,6 +360,8 @@ void mx_altitude(u8 line)
 #else
 		limit_high = 9999;
 #endif
+#endif
+#ifdef CONFIG_ALTITUDE_UNIT_SETTABLE
 	}
 #endif
 	// Loop values until all are set or user breaks	set
@@ -366,8 +374,15 @@ void mx_altitude(u8 line)
 		if (button.flag.star) 
 		{
 			// When using English units, convert ft back to m before updating pressure table
-#ifndef CONFIG_METRIC_ONLY
-			if (!sys.flag.use_metric_units) altitude = convert_ft_to_m((s16)altitude);
+#ifdef CONFIG_ALTITUDE_UNIT_SETTABLE
+			if (!sys.flag.use_metric_units)
+			{
+#endif
+#if defined(CONFIG_ALTITUDE_UNIT_SETTABLE) | defined(CONFIG_ALTITUDE_UNIT_FEET)
+				altitude = convert_ft_to_m((s16)altitude);
+#endif
+#ifdef CONFIG_ALTITUDE_UNIT_SETTABLE
+			}
 #endif
 
 			// Update pressure table
@@ -404,7 +419,7 @@ void mx_altitude(u8 line)
 void display_altitude(u8 line, u8 update)
 {
 	u8 * str;
-#ifndef CONFIG_METRIC_ONLY
+#if defined(CONFIG_ALTITUDE_UNIT_SETTABLE) | defined(CONFIG_ALTITUDE_UNIT_FEET)
 	s16 ft;
 #endif
 	
@@ -419,18 +434,24 @@ void display_altitude(u8 line, u8 update)
 #ifdef CONFIG_ALTI_ACCUMULATOR
 		display_chars(LCD_SEG_L1_3_0, (u8*)"ALT ", SEG_ON);
 #endif
-#ifdef CONFIG_METRIC_ONLY
-			display_symbol(LCD_UNIT_L1_M, SEG_ON);
-#else		
+#ifdef CONFIG_ALTITUDE_UNIT_SETTABLE	
 		if (sys.flag.use_metric_units)
 		{
+#endif
+#if defined(CONFIG_ALTITUDE_UNIT_SETTABLE) | defined(CONFIG_ALTITUDE_UNIT_METERS)
 			// Display "m" symbol
 			display_symbol(LCD_UNIT_L1_M, SEG_ON);
+#endif
+#ifdef CONFIG_ALTITUDE_UNIT_SETTABLE
 		}
 		else
 		{
+#endif
+#if defined(CONFIG_ALTITUDE_UNIT_SETTABLE) | defined(CONFIG_ALTITUDE_UNIT_FEET)
 			// Display "ft" symbol
 			display_symbol(LCD_UNIT_L1_FT, SEG_ON);
+#endif
+#ifdef CONFIG_ALTITUDE_UNIT_SETTABLE
 		}
 #endif		
 		// Display altitude
@@ -441,10 +462,11 @@ void display_altitude(u8 line, u8 update)
 		// Update display only while measurement is active
 		if (sAlt.timeout > 0)
 		{
-#ifndef CONFIG_METRIC_ONLY
+#ifdef CONFIG_ALTITUDE_UNIT_SETTABLE
 			if (sys.flag.use_metric_units)
 			{
 #endif
+#if defined(CONFIG_ALTITUDE_UNIT_SETTABLE) | defined(CONFIG_ALTITUDE_UNIT_METERS)
 				// Display altitude in xxxx m format, allow 3 leading blank digits
 				if (sAlt.altitude >= 0)
 				{
@@ -466,10 +488,13 @@ void display_altitude(u8 line, u8 update)
 					display_symbol(LCD_SYMB_ARROW_UP, SEG_OFF);
 					display_symbol(LCD_SYMB_ARROW_DOWN, SEG_ON);
 				}
-#ifndef CONFIG_METRIC_ONLY
+#endif
+#ifdef CONFIG_ALTITUDE_UNIT_SETTABLE
 			}
 			else
 			{
+#endif
+#if defined(CONFIG_ALTITUDE_UNIT_SETTABLE) | defined(CONFIG_ALTITUDE_UNIT_FEET)
 				// Convert from meters to feet
 				ft = convert_m_to_ft(sAlt.altitude);
 #ifndef CONFIG_ALTI_ACCUMULATOR
@@ -497,6 +522,8 @@ void display_altitude(u8 line, u8 update)
 					display_symbol(LCD_SYMB_ARROW_UP, SEG_OFF);
 					display_symbol(LCD_SYMB_ARROW_DOWN, SEG_ON);
 				}				
+#endif
+#ifdef CONFIG_ALTITUDE_UNIT_SETTABLE
 			}
 #endif
 #ifdef CONFIG_ALTI_ACCUMULATOR

--- a/tools/config.py
+++ b/tools/config.py
@@ -133,14 +133,26 @@ DATA["CONFIG_ALTITUDE"] = {
         "help": "Messures altitude"
         }
 
+DATA["CONFIG_ALTITUDE_UNIT_METERS"] = {
+        "name": "  Always show altitude in metres (-342 bytes)",
+        "depends": [],
+        "default": False,
+        "help": "Overrides any global unit setting"}
+
+DATA["CONFIG_ALTITUDE_UNIT_FEET"] = {
+        "name": "  Always show altitude in feet (-176 bytes)",
+        "depends": [],
+        "default": False,
+        "help": "Overrides any global unit setting/metric only mode"}
 
 DATA["CONFIG_VARIO"] = {
-        "name": "Combined with alti, gives vertical speed (478 bytes)",
+        "name": "  Vertical speed indicator (478 bytes)",
         "depends": [],
-        "default": False}
+        "default": False,
+        "help": "Must have altimeter enabled and active to function"}
 
 DATA["CONFIG_ALTI_ACCUMULATOR"] = {
-	"name": "Altitude accumulator (1068 bytes)",
+	"name": "  Altitude accumulator (1068 bytes)",
 	"depends": [],
 	"default": False,
 	"help": "If active take altitude measurement once per minute and accumulate all ascending vertical meters."


### PR DESCRIPTION
This both saves space, and lets people have metric temperature and altitude in feet at the same time (feet for altitude is still too common, alas).

I've tested all three modes (metres, feet, settable), and it seems to work fine.
